### PR TITLE
Use GCP Project ID for Pub/Sub

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -17,7 +17,12 @@
         "required": true
       },
       "projectId": {
-        "title": "Project ID",
+        "title": "SDM Project ID",
+        "type": "string",
+        "required": true
+      },
+      "gcpProjectId": {
+        "title": "GCP Project ID",
         "type": "string",
         "required": true
       },

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -2,6 +2,7 @@ export type Config = {
     clientId: string,
     clientSecret: string,
     projectId: string,
+    gcpProjectId: string,
     refreshToken: string,
     subscriptionId: string,
     vEncoder?: string

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -34,7 +34,7 @@ export class Platform implements DynamicPlatformPlugin {
 
         const options = config as unknown as Config;
 
-        if (!options || !options.projectId || !options.clientId || !options.clientSecret || !options.refreshToken || !options.subscriptionId) {
+        if (!options || !options.projectId || !options.clientId || !options.clientSecret || !options.refreshToken || !options.subscriptionId || !options.gcpProjectId) {
             log.error(`${config.platform} is not configured correctly. The configuration provided was: ${JSON.stringify(options)}`)
             return;
         }

--- a/src/sdm/Api.ts
+++ b/src/sdm/Api.ts
@@ -38,7 +38,7 @@ export class SmartDeviceManagement {
 
         try {
             this.pubSubClient = new pubsub.PubSub({
-                projectId: config.projectId,
+                projectId: config.gcpProjectId,
                 credentials: {
                     // @ts-ignore
                     type: 'authorized_user',


### PR DESCRIPTION
Use GCP Project ID for Pub/Sub as SDM (Device Access) Project ID doesn't work.

Hit the following error (time and Project ID masked for privacy) while I'm sure the OAuth token has `https://www.googleapis.com/auth/pubsub` granted.  After a few trial and errors I've found if I use the GCP Project ID for Pub/Sub it would work perfectly.

The pull request in its current form clearly could break existing configuration since it mandates a new field.  I'm happy to make additional changes if needed.

```
[01/01/2022, 00:00:00] [homebridge-google-nest-sdm] Plugin initialization failed, there was a failure with event subscription. Did you read the readme: https://github.com/potmat/homebridge-google-nest-sdm#where-do-the-config-values-come-from StatusError: Requested project not found or user does not have access to it (project=01234567-89ab-cdef-0123-456789abcdef). Make sure to specify the unique project identifier and not the Google Cloud Console display name.
    at MessageStream._onEnd (/usr/local/lib/node_modules/homebridge-google-nest-sdm/node_modules/@google-cloud/pubsub/src/message-stream.ts:301:20)
    at MessageStream._onStatus (/usr/local/lib/node_modules/homebridge-google-nest-sdm/node_modules/@google-cloud/pubsub/src/message-stream.ts:342:12)
    at ClientDuplexStreamImpl.<anonymous> (/usr/local/lib/node_modules/homebridge-google-nest-sdm/node_modules/@google-cloud/pubsub/src/message-stream.ts:198:38)
    at Object.onceWrapper (node:events:510:26)
    at ClientDuplexStreamImpl.emit (node:events:390:28)
    at Object.onReceiveStatus (/usr/local/lib/node_modules/homebridge-google-nest-sdm/node_modules/@grpc/grpc-js/src/client.ts:675:16)
    at Object.onReceiveStatus (/usr/local/lib/node_modules/homebridge-google-nest-sdm/node_modules/@grpc/grpc-js/src/client-interceptors.ts:424:48)
    at /usr/local/lib/node_modules/homebridge-google-nest-sdm/node_modules/@grpc/grpc-js/src/call-stream.ts:323:24
    at processTicksAndRejections (node:internal/process/task_queues:78:11) {
  code: 5,
  details: 'Requested project not found or user does not have access to it (project=1234567-89ab-cdef-0123-456789abcdef). Make sure to specify the unique project identifier and not the Google Cloud Console display name.',
  metadata: Metadata { internalRepr: Map(0) {}, options: {} }
}
```