### PR TITLE
Added an optional config to use a switch for Eco Mode on thermostats.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -40,6 +40,11 @@
         "title": "Video Encoder",
         "type": "string",
         "required": false
+      },
+      "isEcoSwitchEnabled": {
+        "title": "Create a Switch instead of a custom characteristic to indicate and control Eco Mode for each thermostat",
+        "type": "boolean",
+        "required": false
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-google-nest-sdm",
-  "version": "1.1.4",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-google-nest-sdm",
-      "version": "1.1.4",
+      "version": "1.1.8",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/pubsub": "^2.18.1",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -5,5 +5,6 @@ export type Config = {
     refreshToken: string,
     subscriptionId: string,
     gcpProjectId?: string,
-    vEncoder?: string
+    vEncoder?: string,
+    isEcoSwitchEnabled?: boolean
 }

--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -21,6 +21,8 @@ let IEcoMode: any;
 export class Platform implements DynamicPlatformPlugin {
     public readonly Characteristic: typeof Characteristic & typeof IEcoMode;
     public readonly debugMode: boolean;
+    public readonly options: Config;
+
     private readonly smartDeviceManagement: SmartDeviceManagement | undefined;
     private readonly accessories: PlatformAccessory[] = [];
     private readonly EcoMode;
@@ -34,14 +36,14 @@ export class Platform implements DynamicPlatformPlugin {
         this.EcoMode = EcoMode(api);
         IEcoMode = this.EcoMode;
 
-        const options = config as unknown as Config;
+        this.options = config as unknown as Config;
 
-        if (!options || !options.projectId || !options.clientId || !options.clientSecret || !options.refreshToken || !options.subscriptionId) {
-            log.error(`${config.platform} is not configured correctly. The configuration provided was: ${JSON.stringify(options)}`)
+        if (!this.options || !this.options.projectId || !this.options.clientId || !this.options.clientSecret || !this.options.refreshToken || !this.options.subscriptionId) {
+            log.error(`${config.platform} is not configured correctly. The configuration provided was: ${JSON.stringify(this.options)}`)
             return;
         }
 
-        this.smartDeviceManagement = new SmartDeviceManagement(options, log);
+        this.smartDeviceManagement = new SmartDeviceManagement(this.options, log);
         // When this event is fired it means Homebridge has restored all cached accessories from disk.
         // Dynamic Platform plugins should only register new accessories after this event was fired,
         // in order to ensure they weren't added to homebridge already. This event can also be used

--- a/src/ThermostatAccessory.ts
+++ b/src/ThermostatAccessory.ts
@@ -256,7 +256,7 @@ export class ThermostatAccessory extends Accessory<Thermostat> {
             this.service.updateCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState, this.platform.Characteristic.TargetHeatingCoolingState.OFF);
         }
 
-        this.service.getCharacteristic(this.platform.Characteristic.EcoMode)?.updateValue(mode.mode === Traits.EcoModeType.MANUAL_ECO);
+        this.service.testCharacteristic(this.platform.Characteristic.EcoMode) && this.service.updateCharacteristic(this.platform.Characteristic.EcoMode, mode.mode === Traits.EcoModeType.MANUAL_ECO);
         this.accessory.getService('Eco Mode')?.updateCharacteristic(this.platform.Characteristic.On, mode.mode === Traits.EcoModeType.MANUAL_ECO)
     }
 


### PR DESCRIPTION
Default to the current behavior of using a custom characteristic.

Custom characteristics are not visible through the default Home application.

Using a switch within the accessory provides an option for anyone who wants to keep all automations compatible with the Home app.