### PR TITLE
Fix: Fix fahrenheit accuracy and step size

### DIFF
--- a/src/ThermostatAccessory.ts
+++ b/src/ThermostatAccessory.ts
@@ -82,15 +82,13 @@ export class ThermostatAccessory extends Accessory<Thermostat> {
 
         let tempUnits = await this.device.getTemperatureUnits();
 
-        let tempStep, minSetTemp, maxSetTemp, minGetTemp, maxGetTemp;
+        let tempStep = 0.1, minSetTemp, maxSetTemp, minGetTemp, maxGetTemp;
         if (tempUnits == TemperatureScale.FAHRENHEIT) {
-            tempStep = 1;
             minSetTemp = this.fahrenheitToCelsius(50);
             maxSetTemp = this.fahrenheitToCelsius(90);
             minGetTemp = this.fahrenheitToCelsius(0);
             maxGetTemp = this.fahrenheitToCelsius(160);
         } else {
-            tempStep = 0.5;
             minSetTemp = 9;
             maxSetTemp = 32;
             minGetTemp = -20;


### PR DESCRIPTION
A step size of 1 causes an incorrect conversion
when displaying fahrenheit and inability to step by 1F

Use the homekit default of 0.1 to provide sufficient precision to fix this.

The Home app temperature widget limits the min step size for the target temperature to 0.5C and 1F.