### PR TITLE
fixing uuid generation for multi-fan support

### DIFF
--- a/src/Platform.ts
+++ b/src/Platform.ts
@@ -116,7 +116,7 @@ export class Platform implements DynamicPlatformPlugin {
 
         devices.filter(device => device instanceof Thermostat).forEach(thermostatDevice => {
             if (this.config.showFan) {
-                const uuid = this.api.hap.uuid.generate(thermostatDevice + ' Fan');
+                const uuid = this.api.hap.uuid.generate(thermostatDevice.getName() + ' Fan');
                 deviceInfos.push({
                     device: thermostatDevice,
                     uuid: uuid,


### PR DESCRIPTION
Previous code that was committed inherited an issue from the prior code that never manifested because there was never more than one fan. `const uuid = this.api.hap.uuid.generate(thermostatDevice + ' Fan'` was not actually generating a unique uuid for each fan, due to the conversion of thermostatDevice to string. Looking at your code, I think we could use `thermostatDevice.getName()` or `thermostatDevice.getDisplayName()`. I used `getName()` here because that is what was used to generate uuids elsewhere in the code.

Duplicate uuids was causing Homekit some trouble pairing with the bridge.